### PR TITLE
dws as python distutils package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+NOT FOR PUBLIC USE
+do not distribute w/o prior consent of Roland Koppe (AWI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+pandas
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
+-e ./
 matplotlib
-pandas
-requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup, find_packages
+
+with open('README.md') as f:
+    readme = f.read()
+
+with open('LICENSE') as f:
+    license = f.read()
+
+setup(
+    name='awi_dws',
+    python_requires='>= 3.6',
+    version="0.1",
+    description='Python wrapper for AWI Data Web Service',
+    long_description=readme,
+    author='Roland Koppe',
+    license=license,
+    py_modules=['dws'],
+    install_requires=[  'pandas',
+                        'requests',
+                        ]
+)


### PR DESCRIPTION
Added setup.py and associate files to enable installation of dws using pip
e.g.`pip install git+https://github.com/cfgmr/dws.git`

Also added requirements file which enables services such as mybinder.org which rely on repo2docker:
https://mybinder.org/v2/gh/cfgmr/dws/master